### PR TITLE
_encode_input_for_recaptcha: catch unicode errors caused by non-ascii

### DIFF
--- a/django_recaptcha_field.py
+++ b/django_recaptcha_field.py
@@ -138,9 +138,12 @@ class _RecaptchaWidget(Widget):
 
 
 def _encode_input_for_recaptcha(string):
-    string_bytes = string.decode(settings.DEFAULT_CHARSET)
-    string_encoded = string_bytes.encode(RECAPTCHA_CHARACTER_ENCODING)
-    return string_encoded
+    try:
+        string_bytes = string.decode(settings.DEFAULT_CHARSET)
+        string_encoded = string_bytes.encode(RECAPTCHA_CHARACTER_ENCODING)
+        return string_encoded
+    except: # non-ascii junk
+        return "bad solution"
 
 
 #}


### PR DESCRIPTION
Before this, django-recaptcha-field caused errors if user entered non-ascii
symbols in the solution.
