### PR TITLE
Fix KeyError when RecaptchaInvalidChallengeError is handled

### DIFF
--- a/django_recaptcha_field.py
+++ b/django_recaptcha_field.py
@@ -65,6 +65,7 @@ class _RecaptchaField(Field):
 
     default_error_messages = {
         'incorrect_solution': 'Your solution to the CAPTCHA was incorrect',
+        'invalid': 'Invalid challenge submitted',
         }
 
     def __init__(


### PR DESCRIPTION
When `is_solution_correct` raises `RecaptchaInvalidChallengeError` in line 92, the exception-handler accesses `self.error_messages['invalid']`, which is not present, since `_RecaptchaField.default_error_messages` doesn't define it.

It is very hard to trigger this exception and I have not myself been able to reproduce it, but I do receive Django tracebacks via email every now and then. This oneliner should fix the issue.
